### PR TITLE
Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha ./dist/test",
-	"postinstall" : "node make babel"
+    "postinstall": "node make babel"
   },
   "bin": {
     "atomiq": "./dist/bin/atomiq.js"
@@ -36,7 +36,8 @@
     "rimraf": "*",
     "semver": "*",
     "shelljs": "*",
-    "source-map-support": "*"
+    "source-map-support": "*",
+    "watch": "^0.17.1"
   },
   "devDependencies": {
     "esformatter": "*",

--- a/src/bin/atomiq-make.js
+++ b/src/bin/atomiq-make.js
@@ -30,7 +30,10 @@ let map = new Map([
     description: 'Force rebuild fresh Docker image for the project',
     action: rebuild
   }],
-  //  [ 'watch-src', { description: 'Watch src directory and update dist', action: watchsrc }],
+  ['watch-src', {
+    description: 'Watch src directory and update dist',
+    action: watchsrc
+  }],
   ['watch-dist', {
     description: 'Watch dist directory and restart server',
     action: watchdist

--- a/src/lib/BabelHelper.js
+++ b/src/lib/BabelHelper.js
@@ -41,6 +41,7 @@ export default class BabelHelper {
   static watch(source, dest, options) {
     options = R.merge(defaultOptions, options)
     let watchOptions = {
+      interval: options.interval,
       filter: f => {
         let filter = f => path.extname(f) == '.js'
         let stats = fs.statSync(f)
@@ -49,6 +50,9 @@ export default class BabelHelper {
         }
       }
     }
+
+    // remove watch-specific option (babel fails on unrecognized options)
+    delete options.interval
 
     watchTree(source, watchOptions, () => {
       BabelHelper.transform(source, dest, options)

--- a/src/lib/BabelHelper.js
+++ b/src/lib/BabelHelper.js
@@ -1,10 +1,13 @@
+import * as print from './io/print'
 import es2015 from 'babel-preset-es2015'
 import fs from 'fs'
 import path from 'path'
+import R from 'ramda'
 import Shell from './ShellHelper'
 import syntaxAsyncFunctions from 'babel-plugin-syntax-async-functions'
 import { transformFileSync } from 'babel-core'
 import transformRegenerator from 'babel-plugin-transform-regenerator'
+import { watchTree } from 'watch'
 
 const defaultOptions = {
   sourceMaps: true,
@@ -27,10 +30,28 @@ export default class BabelHelper {
         let result = transformFileSync(srcpath, options || defaultOptions)
         fs.writeFileSync(destpath, result.code, 'utf8')
         fs.writeFileSync(sourcemap, JSON.stringify(result.map), 'utf8')
+        print.ln(`${srcpath} -> ${destpath}`)
       } else if (stats.isDirectory()) {
         BabelHelper.transform(path.join(source, f), path.join(dest, f), options)
       }
 
+    })
+  }
+
+  static watch(source, dest, options) {
+    options = R.merge(defaultOptions, options)
+    let watchOptions = {
+      filter: f => {
+        let filter = f => path.extname(f) == '.js'
+        let stats = fs.statSync(f)
+        if (stats.isFile() && filter(f) || stats.isDirectory()) {
+          return true
+        }
+      }
+    }
+
+    watchTree(source, watchOptions, () => {
+      BabelHelper.transform(source, dest, options)
     })
   }
 }

--- a/src/lib/commands/Make.js
+++ b/src/lib/commands/Make.js
@@ -46,7 +46,8 @@ export default class Make {
 
   watchsrc() {
     Babel.watch('src', 'dist', {
-      sourceMaps: true
+      sourceMaps: true,
+      interval: 1000
     })
   }
 

--- a/src/lib/commands/Make.js
+++ b/src/lib/commands/Make.js
@@ -45,8 +45,9 @@ export default class Make {
   }
 
   watchsrc() {
-    print.ln('spawning babel')
-    Shell.spawn('babel', ['--watch', 'src', '-d', 'dist', '--source-maps'], spawnopts)
+    Babel.watch('src', 'dist', {
+      sourceMaps: true
+    })
   }
 
   watchdist() {


### PR DESCRIPTION
Adds `atomiq make watch-src` support for running babel and updating `dist` when `.js` files change in the `src` directory.