### PR TITLE
add a delay before container restart

### DIFF
--- a/src/lib/commands/Make.js
+++ b/src/lib/commands/Make.js
@@ -55,7 +55,7 @@ export default class Make {
   watchdist() {
     print.ln('While monitoring, you can also enter "rs" in the console to manually restart')
     Shell.spawn('nodemon',
-      ['--legacy-watch', '--watch', 'dist', '-e', 'js,json', '--exec', 'docker-compose up --force-recreate'],
+      ['--legacy-watch', '--delay', '1', '--watch', 'dist', '-e', 'js,json', '--exec', 'docker-compose up --force-recreate'],
       spawnopts)
   }
 }


### PR DESCRIPTION
Add a delay before restarting the container (watch)... avoid too many unnecessary restarts...