### PR TITLE
don't push dist, added prepublish script

### DIFF
--- a/generator/api/template/_gitignore
+++ b/generator/api/template/_gitignore
@@ -1,2 +1,4 @@
+dist/
 node_modules/
 npm-debug.log
+coverage

--- a/generator/api/template/package.json
+++ b/generator/api/template/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "app1 microservice",
   "scripts": {
+    "prepublish": "npm run babel",
     "build": "babel src -d dist --source-maps",
     "start": "node dist",
     "debug": "babel-node-debug --no-preload --web-host 0.0.0.0 ./src/app.js",

--- a/generator/api/template/package.json
+++ b/generator/api/template/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "app1 microservice",
   "scripts": {
-    "prepublish": "npm run babel",
+    "prepublish": "npm run build",
     "build": "babel src -d dist --source-maps",
     "start": "node dist",
     "debug": "babel-node-debug --no-preload --web-host 0.0.0.0 ./src/app.js",

--- a/generator/app/template/_gitignore
+++ b/generator/app/template/_gitignore
@@ -1,2 +1,4 @@
+dist/
 node_modules/
 npm-debug.log
+coverage

--- a/generator/app/template/package.json
+++ b/generator/app/template/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "app1 microservice",
   "scripts": {
+    "prepublish": "npm run babel",
     "build": "babel src -d dist --source-maps",
     "start": "node dist",
     "debug": "babel-node-debug --no-preload --web-host 0.0.0.0 ./src/app.js",

--- a/generator/app/template/package.json
+++ b/generator/app/template/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "app1 microservice",
   "scripts": {
-    "prepublish": "npm run babel",
+    "prepublish": "npm run build",
     "build": "babel src -d dist --source-maps",
     "start": "node dist",
     "debug": "babel-node-debug --no-preload --web-host 0.0.0.0 ./src/app.js",

--- a/generator/lib/template/_gitignore
+++ b/generator/lib/template/_gitignore
@@ -1,2 +1,4 @@
+dist/
 node_modules/
 npm-debug.log
+coverage

--- a/generator/lib/template/package.json
+++ b/generator/lib/template/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "node library package",
   "scripts": {
+    "prepublish": "npm run babel",
     "build": "babel src -d dist --source-maps",
     "babel": "babel-node src/app.js",
     "test": "mocha --compilers js:babel-register src/test",

--- a/generator/lib/template/package.json
+++ b/generator/lib/template/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "node library package",
   "scripts": {
-    "prepublish": "npm run babel",
+    "prepublish": "npm run build",
     "build": "babel src -d dist --source-maps",
     "babel": "babel-node src/app.js",
     "test": "mocha --compilers js:babel-register src/test",


### PR DESCRIPTION
We don't want to push `dist` directories to GitHub. Added a `prepublish` run script to build on `npm install` and `npm publish`.