### PR TITLE
support new project name option

### DIFF
--- a/src/bin/atomiq.js
+++ b/src/bin/atomiq.js
@@ -23,7 +23,7 @@ cli
 
 
 let map = new Map([
-  ['new', {
+  ['new [name]', {
     description: 'Create a new atomiq app',
     action: create
   }],
@@ -68,9 +68,9 @@ if (require.main === module) {
 }
 
 function trywrap(fn) {
-  return async () => {
+  return async (...options) => {
     try {
-      await fn()
+      await fn(...options)
     } catch (err) {
       print.error(err)
       process.exit(1)
@@ -81,13 +81,14 @@ function trywrap(fn) {
 /**
  * Create a new app.
  */
-async function create(options) {
+async function create(...options) {
   const log = debug('atomiq:app:new')
   log('Creating a new app')
 
   let dest = process.cwd()
   let context = {
-    type: 'api'
+    name: options[0],
+    type: 'api',
   }
 
   context = await prompt.newProject(context)
@@ -103,10 +104,10 @@ async function create(options) {
       //chalk.bold('   atomiq test'))
       chalk.bold('   npm install\n   npm test'))
   } else {
-  print.ok('To run the app in a Docker container, enter:\n%s\n%s\n%s',
-    chalk.bold('   cd ' + context.name),
-    chalk.bold('   atomiq make build'),
-    chalk.bold('   atomiq up'))
+    print.ok('To run the app in a Docker container, enter:\n%s\n%s\n%s',
+      chalk.bold('   cd ' + context.name),
+      chalk.bold('   atomiq make build'),
+      chalk.bold('   atomiq up'))
   }
 }
 

--- a/src/lib/io/prompt.js
+++ b/src/lib/io/prompt.js
@@ -13,8 +13,8 @@ export async function newProject(context) {
     name: 'name',
     type: 'input',
     message: 'name',
-    // use project type from previous questions as default project name
-    default: answers => answers.type
+    // if no name option, use project type from previous questions as default project name
+    default: context.name ? context.name : answers => answers.type
   }
 
   let choices = await prompt([


### PR DESCRIPTION
#23 

Can supply an optional name now for `atomiq new [name]` to override the default names (based on project type).