### PR TITLE
Use docker-compose run instead of docker-compose up. See PR for details.

### DIFF
--- a/src/lib/ComposeHelper.js
+++ b/src/lib/ComposeHelper.js
@@ -15,7 +15,7 @@ export default class ComposeHelper {
   }
 
   static test(options) {
-    Shell.spawn('docker-compose', ['-f', 'docker-compose.test.yml', 'up', '--force-recreate'], options)
+    Shell.spawn('docker-compose', ['-f', 'docker-compose.test.yml', 'run', 'sut'], options)
   }
 
   static debug(options) {


### PR DESCRIPTION
Fix #51 

Currently, `atomiq test` runs `docker-compose up`. However, it doesn't work when using dependencies because `docker-compose up` doesn't exit on container exit when it has live dependencies.
Using `docker-compose run` circumvents that situation because the `docker-compose run` exits when the `sut` exits.
